### PR TITLE
Fixed an non-zero error when the expression matrix is empty

### DIFF
--- a/scMulan/scMulan.py
+++ b/scMulan/scMulan.py
@@ -55,7 +55,10 @@ class scMulan:
         cell_expression_dict = self.get_gene_expression_dict(i, matrix)
         expressed_genes = list(cell_expression_dict.keys())[::-1]
         expression_values = list(cell_expression_dict.values())[::-1]
-        max_expression = np.max(expression_values)
+        if len(expression_values) == 0:  # Check if the array is empty
+            max_expression = 0  # Set a default value or handle accordingly
+        else:
+            max_expression = np.max(expression_values)
         bins = np.linspace(0, max_expression, self.n_express_level+1)
         binned_expr = np.digitize(expression_values, bins, right=True)
 

--- a/scMulan/scMulan_npu.py
+++ b/scMulan/scMulan_npu.py
@@ -61,7 +61,10 @@ class scMulan:
         cell_expression_dict = self.get_gene_expression_dict(i, matrix)
         expressed_genes = list(cell_expression_dict.keys())[::-1]
         expression_values = list(cell_expression_dict.values())[::-1]
-        max_expression = np.max(expression_values)
+        if len(expression_values) == 0:  # Check if the array is empty
+            max_expression = 0  # Set a default value or handle accordingly
+        else:
+            max_expression = np.max(expression_values)
         bins = np.linspace(0, max_expression, self.n_express_level+1)
         binned_expr = np.digitize(expression_values, bins, right=True)
 


### PR DESCRIPTION
## Pull Request Information

The error in `scMulan` encountering is due to attempting to find the maximum value in an empty array, which results in a ValueError. To handle this scenario properly, we need to add a check to see if the expression_values array is empty. If it is empty, we can set `max_expression` to 0 or handle it accordingly. This is a sensible approach to avoid the error.

## Error Information

```shell
File /scratch/users/steorra/miniforge3/envs/omicverse/lib/python3.10/site-packages/omicverse/externel/scMulan/scMulan.py:58, in scMulan.prepare_gene_expression_codings(self, i, matrix)
56 expressed_genes = list(cell_expression_dict.keys())[::-1]
57 expression_values = list(cell_expression_dict.values())[::-1]
---> 58 max_expression = np.max(expression_values)
59 bins = np.linspace(0, max_expression, self.n_express_level+1)
60 binned_expr = np.digitize(expression_values, bins, right=True)

File <array_function internals>:180, in amax(*args, **kwargs)

File /scratch/users/steorra/miniforge3/envs/omicverse/lib/python3.10/site-packages/numpy/core/fromnumeric.py:2793, in amax(a, axis, out, keepdims, initial, where)
2677 @array_function_dispatch(_amax_dispatcher)
2678 def amax(a, axis=None, out=None, keepdims=np._NoValue, initial=np._NoValue,
2679 where=np._NoValue):
2680 """
2681 Return the maximum of an array or maximum along an axis.
2682
(...)
2791 5
2792 """
-> 2793 return _wrapreduction(a, np.maximum, 'max', axis, None, out,
2794 keepdims=keepdims, initial=initial, where=where)

File /scratch/users/steorra/miniforge3/envs/omicverse/lib/python3.10/site-packages/numpy/core/fromnumeric.py:86, in _wrapreduction(obj, ufunc, method, axis, dtype, out, **kwargs)
83 else:
84 return reduction(axis=axis, out=out, **passkwargs)
---> 86 return ufunc.reduce(obj, axis, dtype, out, **passkwargs)

ValueError: zero-size array to reduction operation maximum which has no identity
```